### PR TITLE
Fix grecaptcha.render() undefined

### DIFF
--- a/addon/components/google-recaptcha/component.js
+++ b/addon/components/google-recaptcha/component.js
@@ -40,17 +40,17 @@ export default Ember.Component.extend({
     if (get(this, 'isDestroyed')) {
       return;
     }
-    
+
     if (!isPresent(get(this, 'sitekey'))) {
       set(this, 'config', getWithDefault(getOwner(this).resolveRegistration('config:environment'), 'googleRecaptcha', {}));
       set(this, 'sitekey', get(this, 'config.siteKey'));
     }
 
     const grecaptcha = window.grecaptcha;
-    if (isNone(grecaptcha)) {
+    if (isNone(grecaptcha) || typeof grecaptcha.render !== 'function') {
       later(() => {
         this.renderReCaptcha();
-      }, 500);
+      }, 50);
     } else {
       let container = this.$()[0],
         properties = getProperties(this, [


### PR DESCRIPTION
This PR fixes a bug where Google ReCaptcha window global may be defined, however the render function is not yet defined before ember-google-recaptcha attempts to render the widget:

```
Uncaught TypeError: grecaptcha.render is not a function
```

This PR:
- Adds a check so type of `grecaptcha.render` is a function before attempting to render
- Adds a `pollForGlobalInterval` config, so users can define the polling interval for checking for the `grecaptcha` global. Defaults to 500ms.